### PR TITLE
fix: update home page browser tab title for consistency

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -4,8 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>GRP | Home</title>
-
+    <title>Welcome Back | GRP</title>
     <!-- Bootstrap 5 CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->


### PR DESCRIPTION
fix: update home page browser tab title for consistency
## What this PR does
- Updated browser tab title from "GRP | Home" to "Welcome Back | GRP"

## Issue
Closes #6 

## Testing
- Tested locally, tab title now consistent with page heading