### PR TITLE
fix: capitalise terms link on register page

### DIFF
--- a/pages/register.html
+++ b/pages/register.html
@@ -180,7 +180,7 @@
           </button>
 
           <div class="mt-3 text-muted small">
-            By creating an account you agree to our <a href="terms.html" class="text-secondary">terms</a>
+            By creating an account you agree to our <a href="Terms.html" class="text-secondary">Terms</a>
           </div>
         </form>
 


### PR DESCRIPTION
## What this PR does
- Capitalised "terms" to "Terms" on register page

## Issue
Closes #10 

## Testing
- Tested locally, capitalisation is correct